### PR TITLE
Fix(): copy to clipboard not working

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,8 @@
 {
   "api": "1.0.0",
-  "editorType": ["figma"],
+  "editorType": [
+    "figma"
+  ],
   "id": "1332869916969321981",
   "name": "Fluent Tokens Exporter",
   "main": "build/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { emit, on, showUI } from '@create-figma-plugin/utilities'
 import { formatHex8 } from 'culori'
-import { convertToCSSVariableName, convertToDotNotation, convertToCamelCase, convertToNestedJSON, formatCSSFromJSON } from './utils'
+import { convertToCSSVariableName, convertToDotNotation, convertToCamelCase, convertToNestedJSON } from './utils'
 import { ResizeWindowHandler, GetVariablesHandler, CopyVariablesHandler, CopyToClipboard } from './types'
 
 export default async function () {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { emit, on, showUI } from '@create-figma-plugin/utilities'
 import { formatHex8 } from 'culori'
-import { convertToCSSVariableName, convertToDotNotation, convertToCamelCase, convertToNestedJSON } from './utils'
+import { convertToCSSVariableName, convertToDotNotation, convertToCamelCase, convertToNestedJSON, formatCSS } from './utils'
 import { ResizeWindowHandler, GetVariablesHandler, CopyVariablesHandler, CopyToClipboard } from './types'
 
 export default async function () {
@@ -307,7 +307,7 @@ export default async function () {
     }
 
     let formattedExportedTokens = JSON.stringify(exportedTokens);
-    formattedExportedTokens = formattedExportedTokens.replace(/\"([^(\")"]+)\":/g, "$1: ").replace(/\"([^(\")"]+)\"/g, "'$1'").replace(/,/g, ";\n ").replace(/{/g, "{\n ").replace(/}/g, ";\n}");
+    formattedExportedTokens = formatCSS(formattedExportedTokens)
 
     // TODO: delete this by keeping the object as a JSON.
     if (exportFormat === "dotNotation") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -326,54 +326,23 @@ export default async function () {
     await Promise.all(promises);
   }
 
-  let getTokenValueCounter = 0;
   async function getTokenValue(token: Variable, variableCollection: VariableCollection, modeId: string, exportFormat: string, valueFormat: string): Promise<void> {
-    // increment the getTokenValueCounter by 1
-    getTokenValueCounter++;
-    // console.log(`GTV token ${getTokenValueCounter} ...`);
-    if (getTokenValueCounter === 1) {
-      // console.log(token, variableCollection, modeId, exportFormat, valueFormat);
-    }
+
     try {
       const collectionId = variableCollection.id;
-      if (getTokenValueCounter === 1) {
-        // console.log(collectionId);
-      }
       const tokenType = token.resolvedType;
-      if (getTokenValueCounter === 1) {
-        // console.log(tokenType);
-      }
       const tokenValue = token.valuesByMode[modeId];
-      if (getTokenValueCounter === 1) {
-        // console.log("tokenValue", tokenValue);
-      }
-      if (getTokenValueCounter === 1) {
-        // console.log('(tokenValue && (tokenValue as VariableAlias).type === "VARIABLE_ALIAS")', (tokenValue && (tokenValue as VariableAlias).type === "VARIABLE_ALIAS"));
-      }
       if (tokenValue && (tokenValue as VariableAlias).type === "VARIABLE_ALIAS") {
-        if (getTokenValueCounter === 1) {
-          // console.log("tokenValue inside conditional", tokenValue);
-        }
         // @ts-ignore
         let variable: Variable | null = null;
-        // console.log('Before getVariableByIdAsync');
         try {
           if ((tokenValue as VariableAlias).type === "VARIABLE_ALIAS") { // Check if tokenValue is of type VariableAlias
             const tokenId = (tokenValue as VariableAlias).id;
-            // console.log('tokenId', tokenId);
             
             variable = await figma.variables.getVariableByIdAsync(tokenId); // Access id property
-            // console.log('After getVariableByIdAsync', variable);
           }
         } catch (error) {
           console.error('An error occurred:', error);
-        }
-        // console.log('After try-catch');
-        // const variable = tokenValue;
-        // console.log("getTokenValueCounter", getTokenValueCounter);
-        if (getTokenValueCounter === 1) {
-          // console.log("tokenValue inside conditional", tokenValue);
-          console.log("variable:", variable);
         }
         if (variable) {
           const variableCollectionOfToken = await figma.variables.getVariableCollectionByIdAsync(variable.variableCollectionId);

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -167,7 +167,7 @@ function Plugin() {
       <VerticalSpace space='large' />
       <Container space='extraSmall'>
         <Stack space='extraSmall'>
-          <Text><Bold><Muted>Variable collectionsss</Muted></Bold></Text>
+          <Text><Bold><Muted>Variable collections</Muted></Bold></Text>
           <Dropdown icon={IconVariableCollection16} onChange={handleCollectionChange} options={collectionOptions} value={collection} />
           <VerticalSpace space='small' />
           <Text><Bold><Muted>Mode</Muted></Bold></Text>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,9 +1,13 @@
-import { Bold, Button, Columns, Container, Dropdown, DropdownOption, Inline, Muted, Preview, SegmentedControl, SegmentedControlOption, Stack, Text, VerticalSpace, render, useWindowResize } from '@create-figma-plugin/ui'
+import { Bold, Button, Container, Dropdown, DropdownOption, Inline, Muted, SegmentedControl, SegmentedControlOption, Stack, Text, VerticalSpace, render, useWindowResize } from '@create-figma-plugin/ui'
 import { emit, on } from '@create-figma-plugin/utilities'
 import { ResizeWindowHandler, GetVariablesHandler, CopyToClipboard, CopyVariablesHandler } from './types'
-import { Fragment, JSX, h } from 'preact';
+import { JSX, h } from 'preact';
 import { useState } from 'preact/hooks';
-import styles from './styles.css'
+import styles from './styles.css';
+
+const IconVariableMode16 = <svg class="svg" xmlns="http://www.w3.org/2000/svg" width="14" height="12" viewBox="0 0 14 12"><path fill="var(--figma-color-text)" fill-opacity="1" fill-rule="evenodd" stroke="none" d="m5 1.381-4 2.31v4.618l4 2.31 4-2.31V3.691L5 1.38zm5 1.732L5 .227 0 3.113v5.774l5 2.887 5-2.887V3.113zm3 5.196-5 2.887 1 .578 5-2.887V3.113L9 .227 8 .804l5 2.887v4.618zM6 6c0 .552-.448 1-1 1-.552 0-1-.448-1-1 0-.552.448-1 1-1 .552 0 1 .448 1 1z"></path></svg>;
+const IconVariableCollection16 = <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2 4.5C2 3.11929 3.11929 2 4.5 2H11.5C12.8807 2 14 3.11929 14 4.5V11.5C14 12.8807 12.8807 14 11.5 14H4.5C3.11929 14 2 12.8807 2 11.5V4.5ZM6 13H10V11L6 11V13ZM5 11H3V11.5C3 12.3284 3.67157 13 4.5 13H5V11ZM6 10L10 10V6L6 6V10ZM5 6H3V10H5V6ZM6 5L10 5V3H6V5ZM5 3H4.5C3.67157 3 3 3.67157 3 4.5V5H5V3ZM13 6H11V10H13V6ZM13 11H11V13H11.5C12.3284 13 13 12.3284 13 11.5V11ZM13 5V4.5C13 3.67157 12.3284 3 11.5 3H11V5H13Z" fill="var(--figma-color-text)" /></svg>;
+const IconCopy16 = <svg width="16" height="12" fill="none" xmlns="http://www.w3.org/2000/svg" style="overflow: visible; margin-right: 6px"><path d="M4.00029 4.08525L4 10.5C4 11.8255 5.03154 12.91 6.33562 12.9947L6.5 13L10.9144 13.0007C10.7083 13.5829 10.1528 14 9.5 14H6C4.34315 14 3 12.6569 3 11V5.5C3 4.84678 3.41754 4.29109 4.00029 4.08525ZM11.5 2C12.3284 2 13 2.67157 13 3.5V10.5C13 11.3284 12.3284 12 11.5 12H6.5C5.67157 12 5 11.3284 5 10.5V3.5C5 2.67157 5.67157 2 6.5 2H11.5ZM11.5 3H6.5C6.22386 3 6 3.22386 6 3.5V10.5C6 10.7761 6.22386 11 6.5 11H11.5C11.7761 11 12 10.7761 12 10.5V3.5C12 3.22386 11.7761 3 11.5 3Z" fill="var(--figma-color-text-onbrand)" /></svg>;
 
 function Plugin() {
   function onWindowResize(windowSize: { width: number; height: number }) {
@@ -17,7 +21,6 @@ function Plugin() {
     resizeBehaviorOnDoubleClick: 'minimize'
   })
 
-
   const [localVariableCollections, setLocalVariableCollections]: [VariableCollection[], Function] = useState<VariableCollection[]>([])
   const [collectionOptions, setCollectionOptions]: [DropdownOption[], Function] = useState<DropdownOption[]>([{ value: "All variable collections" }, '-']);
   const [modeOptions, setModeOptions]: [DropdownOption[], Function] = useState<DropdownOption[]>([{ value: "All modes" }]);
@@ -27,48 +30,13 @@ function Plugin() {
   const [exportFormat, setExportFormat] = useState<string>("cssVar");
 
   const [valueFormat, setValueFormat] = useState<string>('Raw value');
-  const valueFormatOptions: Array<SegmentedControlOption> = [{
-    value: 'Raw value'
-  }, {
-    value: 'Alias name'
-  }];
+  const valueFormatOptions: Array<SegmentedControlOption> = [{ value: 'Raw value' }, { value: 'Alias name' }];
+
+
   function handleValueFormatChange(event: JSX.TargetedEvent<HTMLInputElement>) {
     const newValue = event.currentTarget.value;
-    //console.log(newValue);
     setValueFormat(newValue);
   }
-
-
-  const IconVariableMode16 = <svg class="svg" xmlns="http://www.w3.org/2000/svg" width="14" height="12" viewBox="0 0 14 12"><path fill="var(--figma-color-text)" fill-opacity="1" fill-rule="evenodd" stroke="none" d="m5 1.381-4 2.31v4.618l4 2.31 4-2.31V3.691L5 1.38zm5 1.732L5 .227 0 3.113v5.774l5 2.887 5-2.887V3.113zm3 5.196-5 2.887 1 .578 5-2.887V3.113L9 .227 8 .804l5 2.887v4.618zM6 6c0 .552-.448 1-1 1-.552 0-1-.448-1-1 0-.552.448-1 1-1 .552 0 1 .448 1 1z"></path></svg>
-  const IconVariableCollection16 = <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2 4.5C2 3.11929 3.11929 2 4.5 2H11.5C12.8807 2 14 3.11929 14 4.5V11.5C14 12.8807 12.8807 14 11.5 14H4.5C3.11929 14 2 12.8807 2 11.5V4.5ZM6 13H10V11L6 11V13ZM5 11H3V11.5C3 12.3284 3.67157 13 4.5 13H5V11ZM6 10L10 10V6L6 6V10ZM5 6H3V10H5V6ZM6 5L10 5V3H6V5ZM5 3H4.5C3.67157 3 3 3.67157 3 4.5V5H5V3ZM13 6H11V10H13V6ZM13 11H11V13H11.5C12.3284 13 13 12.3284 13 11.5V11ZM13 5V4.5C13 3.67157 12.3284 3 11.5 3H11V5H13Z" fill="var(--figma-color-text)" /></svg>
-  const IconCopy16 = <svg width="16" height="12" fill="none" xmlns="http://www.w3.org/2000/svg" style="overflow: visible; margin-right: 6px"><path d="M4.00029 4.08525L4 10.5C4 11.8255 5.03154 12.91 6.33562 12.9947L6.5 13L10.9144 13.0007C10.7083 13.5829 10.1528 14 9.5 14H6C4.34315 14 3 12.6569 3 11V5.5C3 4.84678 3.41754 4.29109 4.00029 4.08525ZM11.5 2C12.3284 2 13 2.67157 13 3.5V10.5C13 11.3284 12.3284 12 11.5 12H6.5C5.67157 12 5 11.3284 5 10.5V3.5C5 2.67157 5.67157 2 6.5 2H11.5ZM11.5 3H6.5C6.22386 3 6 3.22386 6 3.5V10.5C6 10.7761 6.22386 11 6.5 11H11.5C11.7761 11 12 10.7761 12 10.5V3.5C12 3.22386 11.7761 3 11.5 3Z" fill="var(--figma-color-text-onbrand)" /></svg>
-
-
-  /**
-   * Unsecured fallback for copying text to clipboard
-   * @param text - The text to be copied to the clipboard
-   */
-  function unsecuredCopyToClipboard(text: string) {
-    // Create a textarea element
-    const textArea = document.createElement('textarea');
-    textArea.value = text;
-    document.body.appendChild(textArea);
-
-    // Focus and select the textarea content
-    textArea.focus();
-    textArea.select();
-
-    // Attempt to copy the text to the clipboard
-    try {
-      document.execCommand('copy');
-    } catch (e) {
-      console.error('Unable to copy content to clipboard!', e);
-    }
-
-    // Remove the textarea element from the DOM
-    document.body.removeChild(textArea);
-  }
-
   /**
    * Copies the text passed as param to the system clipboard
    * Check if using HTTPS and navigator.clipboard is available
@@ -98,9 +66,33 @@ function Plugin() {
     }
   }
 
+  /**
+   * Unsecured fallback for copying text to clipboard
+   * @param text - The text to be copied to the clipboard
+   */
+  function unsecuredCopyToClipboard(text: string) {
+    // Create a textarea element
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    document.body.appendChild(textArea);
+
+    // Focus and select the textarea content
+    textArea.focus();
+    textArea.select();
+
+    // Attempt to copy the text to the clipboard
+    try {
+      document.execCommand('copy');
+    } catch (e) {
+      console.error('Unable to copy content to clipboard!', e);
+    }
+
+    // Remove the textarea element from the DOM
+    document.body.removeChild(textArea);
+  }
+
+
   on<CopyToClipboard>('COPY_TO_CLIPBOARD', (text) => {
-    // console.log("ui.tsx - on<CopyToClipboard>", text)
-    // Copy the text to the clipboard
     copyToClipboard(text);
   });
 
@@ -121,22 +113,18 @@ function Plugin() {
   })
 
   function handleCopy(event: JSX.TargetedEvent<HTMLButtonElement>) {
-    const selectedCollection = localVariableCollections.find((element) => element.name == collection)
-    const selectedMode = selectedCollection?.modes.find((element) => element.name == mode)
-    emit<CopyVariablesHandler>('COPY_VARIABLES', selectedCollection, selectedMode, exportFormat, valueFormat)
-
-
+    const selectedCollection = localVariableCollections.find((element) => element.name == collection);
+    const selectedMode = selectedCollection?.modes.find((element) => element.name == mode);
+    emit<CopyVariablesHandler>('COPY_VARIABLES', selectedCollection, selectedMode, exportFormat, valueFormat);
   }
 
 
   function handleCollectionChange(event: JSX.TargetedEvent<HTMLInputElement>) {
     const newValue = event.currentTarget.value;
     let newModesOptions: Array<{ value: string; } | { header: string; } | string> = [];
-    // console.log(newValue);
     setCollection(newValue);
     // find the element in the localVariableCollections array, in which collection.name == newValue
     const selectedCollection = localVariableCollections.find((collection) => collection.name == newValue)
-    // console.log("ui.tsx - handleCollectionChange - selectedCollection", selectedCollection)
     // based on the selectedCollection, create a new array of modes to replace the modeOptions
     if (selectedCollection) {
       newModesOptions.push({ value: "All modes" })
@@ -145,7 +133,6 @@ function Plugin() {
       selectedCollection.modes.forEach((mode) => {
         newModesOptions.push({ value: mode.name })
       })
-      // console.log("ui.tsx - handleCollectionChange - newModesOptions", newModesOptions)
       // replace the modeOptions with the new array
       setModeOptions(newModesOptions)
     } else {
@@ -166,15 +153,11 @@ function Plugin() {
 
   function handleModeChange(event: JSX.TargetedEvent<HTMLInputElement>) {
     const newValue = event.currentTarget.value;
-    // console.log(newValue);
-    // console.log(modeOptions);
     setMode(newValue);
   }
 
   function handleExportFormatChange(event: JSX.TargetedEvent<HTMLInputElement>) {
     const newValue = event.currentTarget.value;
-    // console.log(newValue);
-    // console.log(formatOptions);
     setExportFormat(newValue);
   }
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -21,14 +21,10 @@ function Plugin() {
   const [localVariableCollections, setLocalVariableCollections]: [VariableCollection[], Function] = useState<VariableCollection[]>([])
   const [collectionOptions, setCollectionOptions]: [DropdownOption[], Function] = useState<DropdownOption[]>([{ value: "All variable collections" }, '-']);
   const [modeOptions, setModeOptions]: [DropdownOption[], Function] = useState<DropdownOption[]>([{ value: "All modes" }]);
-  const [formatOptions, setFormatOptions]: [DropdownOption[], Function] = useState<DropdownOption[]>([{ text: "--css-variable-name", value: "cssVar" }, { text: "camelCase", value: "camelCase" }, { text: "JSON", value: "dotNotation" }]);
 
   const [collection, setCollection] = useState<string>("All variable collections");
   const [mode, setMode] = useState<string>("All modes");
   const [exportFormat, setExportFormat] = useState<string>("cssVar");
-  const [selectedCollection, setSelectedCollection] = useState<VariableCollection | null>(null);
-  const [selectedMode, setSelectedMode] = useState<Variable | null>(null);
-
 
   const [valueFormat, setValueFormat] = useState<string>('Raw value');
   const valueFormatOptions: Array<SegmentedControlOption> = [{
@@ -109,7 +105,6 @@ function Plugin() {
   });
 
   on<GetVariablesHandler>('GET_VARIABLES', (localVariableCollections) => {
-    // console.log("ui.tsx - on<GetVariablesHandler>", localVariableCollections)
     setLocalVariableCollections(localVariableCollections)
     let newCollectionOptions: { value: string; }[] = []
     let newModesOptions: Array<{ value: string; } | { header: string; } | string> = [];
@@ -126,10 +121,6 @@ function Plugin() {
   })
 
   function handleCopy(event: JSX.TargetedEvent<HTMLButtonElement>) {
-    // console.log("ui.tsx - handleCopy - collection", collection)
-    // console.log("ui.tsx - handleCopy - mode", mode)
-    //console.log("ui.tsx - handleCopy - exportFormat", exportFormat);
-    //console.log("ui.tsx - handleCopy - valueFormat", valueFormat);
     const selectedCollection = localVariableCollections.find((element) => element.name == collection)
     const selectedMode = selectedCollection?.modes.find((element) => element.name == mode)
     emit<CopyVariablesHandler>('COPY_VARIABLES', selectedCollection, selectedMode, exportFormat, valueFormat)
@@ -200,7 +191,7 @@ function Plugin() {
           <Dropdown icon={IconVariableMode16} onChange={handleModeChange} options={modeOptions} value={mode} />
           <VerticalSpace space='small' />
           <Text><Bold><Muted>Export format</Muted></Bold></Text>
-          <Dropdown onChange={handleExportFormatChange} options={formatOptions} value={exportFormat} />
+          <Dropdown onChange={handleExportFormatChange} options={[{ text: "--css-variable-name", value: "cssVar" }, { text: "camelCase", value: "camelCase" }, { text: "JSON", value: "dotNotation" }]} value={exportFormat} />
           <SegmentedControl onChange={handleValueFormatChange} options={valueFormatOptions} value={valueFormat} />
         </Stack>
       </Container>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -167,7 +167,7 @@ function Plugin() {
       <VerticalSpace space='large' />
       <Container space='extraSmall'>
         <Stack space='extraSmall'>
-          <Text><Bold><Muted>Variable collection</Muted></Bold></Text>
+          <Text><Bold><Muted>Variable collectionsss</Muted></Bold></Text>
           <Dropdown icon={IconVariableCollection16} onChange={handleCollectionChange} options={collectionOptions} value={collection} />
           <VerticalSpace space='small' />
           <Text><Bold><Muted>Mode</Muted></Bold></Text>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,4 +61,27 @@ function convertToCSSVariableName(input: string): string {
     return variableName.replace(/-+$/, '');
 }
 
-export { convertToDotNotation, convertToNestedJSON, convertToCamelCase, convertToCSSVariableName };
+//Todo: DELETE ME, instead of going from JSON to CSS back to JSON. Keep it as JSON.
+function formatCSS(formattedExportedTokens: string): string {
+
+    // Replace quoted keys in JSON (excluding the colon) with unquoted keys
+    formattedExportedTokens = formattedExportedTokens.replace(/\"([^(\")"]+)\":/g, "$1: ");
+
+    // Replace double quotes around values with single quotes
+    formattedExportedTokens = formattedExportedTokens.replace(/\"([^(\")"]+)\"/g, "'$1'");
+
+    // Replace commas with a semicolon and a newline, adding two spaces for indentation
+    formattedExportedTokens = formattedExportedTokens.replace(/,/g, ";\n  ");
+
+    // Add a newline and two spaces after every opening brace for better readability
+    formattedExportedTokens = formattedExportedTokens.replace(/{/g, "{\n  ");
+
+    // Add a semicolon, newline, and closing brace to close scopes neatly
+    formattedExportedTokens = formattedExportedTokens.replace(/}/g, ";\n}");
+
+    return formattedExportedTokens;
+}
+
+//   .replace(/\"([^(\")"]+)\":/g, "$1: ").replace(/\"([^(\")"]+)\"/g, "'$1'").replace(/,/g, ";\n ").replace(/{/g, "{\n ").replace(/}/g, ";\n}");
+
+export { convertToDotNotation, convertToNestedJSON, convertToCamelCase, convertToCSSVariableName, formatCSS };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,4 +61,4 @@ function convertToCSSVariableName(input: string): string {
     return variableName.replace(/-+$/, '');
 }
 
-export { convertToDotNotation, convertToNestedJSON, convertToCamelCase, convertToCSSVariableName };
+export { convertToDotNotation, convertToNestedJSON, convertToCamelCase, convertToCSSVariableName, formatCSSFromJSON };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,64 @@
+function convertToDotNotation(input: string): string {
+    const withoutParentheses = input.replace(/\(.*?\)/g, '');
+    const withoutDoubleSlashes = withoutParentheses.replace(/\/\//g, '/');
+    const dotNotation = withoutDoubleSlashes.split('/').map(part => {
+      return part.split(/[^a-zA-Z0-9-]/).map((word, index) => {
+        return index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+      }).join('');
+    }).join('.');
+    // remove any trailing dots
+    return dotNotation.replace(/\.$/, '');
+  }
+
+
+// create a function based on `https://second-editors-draft.tr.designtokens.org/format/` to convert a string to a nested JSON object in the format of the Design Tokens specification. Example: ```  "token name": {"$value": "token value"}```
+function convertToNestedJSON(input: string, value: any): any {
+    const withoutParentheses = input.replace(/\(.*?\)/g, '');
+    const withoutDoubleSlashes = withoutParentheses.replace(/\/\//g, '/');
+    const parts = withoutDoubleSlashes.split('/');
+
+    let nestedObject: { [key: string]: any } = {}; // Add index signature to allow indexing with a string
+    let currentLevel = nestedObject;
+
+    for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (i === parts.length - 1) {
+        currentLevel[part] = { "$value": value };
+        } else {
+        currentLevel[part] = {};
+        currentLevel = currentLevel[part];
+        }
+    }
+
+    return nestedObject;
+}
+
+
+function convertToCamelCase(input: string): string {
+    const withoutParentheses = input.replace(/\(.*?\)/g, '');
+    const withoutDoubleSlashes = withoutParentheses.replace(/\/\//g, '/');
+    let variableName = withoutDoubleSlashes.split(/[^a-zA-Z0-9-]/).map((word, index) => {
+        if (index === 0) {
+        return word.toLowerCase();
+        } else {
+        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        }
+    }).join('');
+
+    return variableName;
+}
+
+function convertToCSSVariableName(input: string): string {
+    const withoutParentheses = input.replace(/\(.*?\)/g, '');
+    // replace any double slashes with a single slash `/`
+    const withoutDoubleSlashes = withoutParentheses.replace(/\/\//g, '/');
+    const variableName = "--" + withoutDoubleSlashes.split('/').map(part => {
+        return part.split(/[^a-zA-Z0-9-]/).map((word, index) => {
+        return index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        }).join('');
+    }).join('-');
+    // remove any trailing hyphens
+    return variableName.replace(/-+$/, '');
+}
+
+export { convertToDotNotation, convertToNestedJSON, convertToCamelCase, convertToCSSVariableName };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,4 +61,4 @@ function convertToCSSVariableName(input: string): string {
     return variableName.replace(/-+$/, '');
 }
 
-export { convertToDotNotation, convertToNestedJSON, convertToCamelCase, convertToCSSVariableName, formatCSSFromJSON };
+export { convertToDotNotation, convertToNestedJSON, convertToCamelCase, convertToCSSVariableName };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,6 +1206,11 @@ preact@>=10:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.22.0.tgz#a50f38006ae438d255e2631cbdaf7488e6dd4e16"
   integrity sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==
 
+prettier@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
+  integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"


### PR DESCRIPTION
**Problem**
1. When releasing new versions of the plugin, the copy to clipboard feature doesn't copy the entire list:
![image](https://github.com/Jeremy-Knudsen/Fluent-Tokens-Exporter/assets/11350529/831279c8-9b74-4494-af25-e96eed688b75)

2. Exporting the `Alias name` mode, it should give the `aliasName` of the selected Mode, follow the mode down to it's referenced value.
<img width="1703" alt="image" src="https://github.com/Jeremy-Knudsen/Fluent-Tokens-Exporter/assets/11350529/949113ff-a8c6-4f33-a48d-748fe1c0e2a2">

3. Keep the `-` for when it's in the name
<img width="256" alt="image" src="https://github.com/Jeremy-Knudsen/Fluent-Tokens-Exporter/assets/11350529/f1d777c6-40cf-4507-83f5-234b969063f3">


**Solution**
1. Update to use async/await && promises.all

2. Update `getTokenValue` to make use of the current variable name rather then look for until there's no raw value.

3. Update functions in `utils.ts`: `convertToDotNotation`, `convertToCamelCase`,  and `convertToCSSVariableName` to include `-` in their regex
